### PR TITLE
feat: permit nullable parent

### DIFF
--- a/src/__tests__/entities/advert.entity.ts
+++ b/src/__tests__/entities/advert.entity.ts
@@ -13,9 +13,9 @@ export class AdvertEntity {
   })
   owner: UserEntity | MerchantEntity;
 
-  @Column()
+  @Column({ nullable: true })
   entityId: number;
 
-  @Column()
+  @Column({ nullable: true })
   entityType: string;
 }

--- a/src/polymorphic.repository.ts
+++ b/src/polymorphic.repository.ts
@@ -127,7 +127,7 @@ export abstract class AbstractPolymorphicRepository<
     return values.reduce<E>((e: E, vals: PolymorphicHydrationType) => {
       const values =
         vals.type === 'parent' && Array.isArray(vals.values)
-          ? vals.values.filter((v) => typeof v !== 'undefined' && v !== null)
+          ? vals.values.filter((v) => typeof v !== 'undefined')
           : vals.values;
       const polys =
         vals.type === 'parent' && Array.isArray(values) ? values[0] : values; // TODO should be condition for !hasMany
@@ -153,7 +153,7 @@ export abstract class AbstractPolymorphicRepository<
     // TODO if not hasMany, should I return if one is found?
     const results = await Promise.all(
       entityTypes.map((type: Function) =>
-        this.findPolymorphs(entity, type, options),
+        type ? this.findPolymorphs(entity, type, options) : null,
       ),
     );
 


### PR DESCRIPTION
At the moment, if there is a record whose `entityType` and `entityId` are `null`, you get an exception when it gets hydrated:

```
EntityMetadataNotFoundError: No metadata for "null" was found.
```

This pull request makes it possible to have a nullable polymorphic parent.