### PR TITLE
fix: use a constistent name for entityId column option

### DIFF
--- a/src/__tests__/entities/advert.entity.ts
+++ b/src/__tests__/entities/advert.entity.ts
@@ -18,4 +18,17 @@ export class AdvertEntity {
 
   @Column({ nullable: true })
   entityType: string;
+
+  @PolymorphicParent(() => [UserEntity, MerchantEntity], {
+    entityTypeColumn: 'creatorType',
+    entityIdColumn: 'creatorId',
+    eager: true,
+  })
+  creator: UserEntity | MerchantEntity;
+
+  @Column({ nullable: true })
+  creatorId: number;
+
+  @Column({ nullable: true })
+  creatorType: string;
 }

--- a/src/__tests__/entities/merchant.entity.ts
+++ b/src/__tests__/entities/merchant.entity.ts
@@ -11,4 +11,11 @@ export class MerchantEntity {
     eager: false,
   })
   adverts: AdvertEntity[];
+
+  @PolymorphicChildren(() => AdvertEntity, {
+    entityTypeColumn: 'creatorType',
+    entityIdColumn: 'creatorId',
+    eager: false,
+  })
+  createdAdverts: AdvertEntity[];
 }

--- a/src/__tests__/entities/user.entity.ts
+++ b/src/__tests__/entities/user.entity.ts
@@ -11,4 +11,11 @@ export class UserEntity {
     eager: false,
   })
   adverts: AdvertEntity[];
+
+  @PolymorphicChildren(() => AdvertEntity, {
+    entityTypeColumn: 'creatorType',
+    entityIdColumn: 'creatorId',
+    eager: false,
+  })
+  createdAdverts: AdvertEntity[];
 }

--- a/src/polymorphic.interface.ts
+++ b/src/polymorphic.interface.ts
@@ -8,7 +8,7 @@ export interface PolymorphicInterface {
   hasMany: boolean;
   primaryColumn?: string;
   entityTypeColumn?: string;
-  entityTypeId?: string;
+  entityIdColumn?: string;
   eager: boolean;
   cascade: boolean;
   deleteBeforeUpdate: boolean;
@@ -31,7 +31,7 @@ export interface PolymorphicDecoratorOptionsInterface {
   cascade?: boolean;
   eager?: boolean;
   entityTypeColumn?: string;
-  entityTypeId?: string;
+  entityIdColumn?: string;
 }
 
 export type PolymorphicChildType = {

--- a/src/polymorphic.repository.ts
+++ b/src/polymorphic.repository.ts
@@ -31,7 +31,7 @@ type PolymorphicHydrationType = {
 const entityTypeColumn = (options: PolymorphicMetadataInterface): string =>
   options.entityTypeColumn || 'entityType';
 const entityIdColumn = (options: PolymorphicMetadataInterface): string =>
-  options.entityTypeId || 'entityId';
+  options.entityIdColumn || 'entityId';
 const PrimaryColumn = (options: PolymorphicMetadataInterface): string =>
   options.primaryColumn || 'id';
 


### PR DESCRIPTION
`entityTypeId` is obviously a typo.