### PR TITLE
fix: Take into account parent's primaryColumn config when fetching fr…

### DIFF
--- a/src/__tests__/entities/admin.entity.ts
+++ b/src/__tests__/entities/admin.entity.ts
@@ -1,0 +1,15 @@
+import { Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { PolymorphicChildren } from '../../../dist';
+import { AdvertEntity } from './advert.entity';
+
+@Entity('admins')
+export class AdminEntity {
+    @PrimaryGeneratedColumn()
+    admin_id: number;
+
+    @PolymorphicChildren(() => AdvertEntity, {
+        eager: false,
+        primaryColumn: "admin_id"
+    })
+    adverts: AdvertEntity[];
+}

--- a/src/__tests__/entities/advert.entity.ts
+++ b/src/__tests__/entities/advert.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { PolymorphicParent } from '../../../dist';
+import { AdminEntity } from './admin.entity';
 import { MerchantEntity } from './merchant.entity';
 import { UserEntity } from './user.entity';
 
@@ -8,10 +9,10 @@ export class AdvertEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @PolymorphicParent(() => [UserEntity, MerchantEntity], {
+  @PolymorphicParent(() => [UserEntity, MerchantEntity, AdminEntity], {
     eager: true,
   })
-  owner: UserEntity | MerchantEntity;
+  owner: UserEntity | MerchantEntity | AdminEntity;
 
   @Column({ nullable: true })
   entityId: number;


### PR DESCRIPTION
…om polymorphic child

Before, on a child repository's options, we didn't handle the case in which there were multiple parents which had different `primaryColumn` names

Now we take such configurations into account. Specifically, we fetch the metadata associated with the parent we are visiting and read its `primaryColumn`. This allows for multiple parents to have different ID names when such situations arise.